### PR TITLE
Compatibility with PIN 3.11

### DIFF
--- a/coveragetools/ddph.c
+++ b/coveragetools/ddph.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string>
+using namespace std;
 #include "pin.H"
 
 typedef char CHAR;


### PR DESCRIPTION
At some point PIN did something to require explicit inclusion of the string class. I had to do the same thing to the PIN tracer in qira.

Just a minor change allows to use PIN 3.11 and probably newer.