### PR TITLE
Reduce saturation of highlighted areas

### DIFF
--- a/src/main/java/dragondance/eng/Painter.java
+++ b/src/main/java/dragondance/eng/Painter.java
@@ -9,7 +9,7 @@ import dragondance.eng.session.SessionManager;
 public class Painter {
 	
 	private static final float BRIGHTNESS = 1.0f;
-	private static final float SATURATION=0.60f;
+	private static final float SATURATION = 0.2f;
 	
 	public static final int CP_USE_MAX_DENSITY = 0;
 	public static final int CP_USE_THRESHOLD_VALUE = 1;


### PR DESCRIPTION
The saturation was so high that other elements like text become nearly illegible, both in the default white theme, and inverted dark theme.
High-saturated colors look distracting in general, especially for backgrounds.

---

Thanks for this extension!