### PR TITLE
fix load coverages on linux

### DIFF
--- a/src/main/java/dragondance/components/GuiAffectedOpInterface.java
+++ b/src/main/java/dragondance/components/GuiAffectedOpInterface.java
@@ -6,6 +6,7 @@ import dragondance.datasource.CoverageData;
 
 public interface GuiAffectedOpInterface {
 	public CoverageData loadCoverage(String coverageDataFile) throws FileNotFoundException;
+	public CoverageData loadCoverage(String coverageDataFile, String varName) throws FileNotFoundException;
 	public boolean removeCoverage(int id);
 	public boolean visualizeCoverage(CoverageData coverage);
 	public boolean goTo(long offset);

--- a/src/main/java/dragondance/datasource/CoverageDataSource.java
+++ b/src/main/java/dragondance/datasource/CoverageDataSource.java
@@ -28,7 +28,7 @@ public class CoverageDataSource implements AutoCloseable{
 	
 	protected List<ModuleInfo> modules;
 	protected List<BlockEntry> entries;
-	
+
 	protected String mainModuleName = null;
 	protected ModuleInfo mainModule = null;
 	
@@ -331,7 +331,8 @@ public class CoverageDataSource implements AutoCloseable{
 		if (!hasCid)
 			return this.mainModule.getId() == entry.getModuleId();
 		
-		return this.mainModule.getContainingId() == entry.getModuleId();
+		return (entry.getModuleId() < this.modules.size() &&
+				this.modules.get(entry.getModuleId()).getContainingId() == this.mainModule.getContainingId());
 	}
 	
 	protected void pushEntry(BlockEntry entry) {

--- a/src/main/java/dragondance/scripting/ScriptExecutionUnit.java
+++ b/src/main/java/dragondance/scripting/ScriptExecutionUnit.java
@@ -49,6 +49,9 @@ public class ScriptExecutionUnit {
 	
 	public boolean execute() {
 		
+		if (hasAssignee())
+			this.function.setNameAssigneeVar(this.assigneeVar.getName());
+		
 		if (this.function.execute() == null) {
 			
 			if (!this.function.hasReturnType())
@@ -57,8 +60,9 @@ public class ScriptExecutionUnit {
 			return false;
 		}
 		
-		if (hasAssignee())
+		if (hasAssignee()) {
 			this.assigneeVar.setResultCoverage(this.function.getReturn());
+		}
 		
 		return true;
 	}

--- a/src/main/java/dragondance/scripting/functions/BuiltinFunctionBase.java
+++ b/src/main/java/dragondance/scripting/functions/BuiltinFunctionBase.java
@@ -13,6 +13,7 @@ public abstract class BuiltinFunctionBase {
 	
 	private List<BuiltinArg> args;
 	private CoverageData retVal;
+	private String nameAssigneeVar;
 	
 	protected GuiAffectedOpInterface guiSvc;
 	
@@ -129,5 +130,13 @@ public abstract class BuiltinFunctionBase {
 			this.aliases.clear();
 		
 		this.args.clear();
+	}
+
+	public String getNameAssigneeVar() {
+		return nameAssigneeVar;
+	}
+
+	public void setNameAssigneeVar(String nameAssigneeVar) {
+		this.nameAssigneeVar = nameAssigneeVar;
 	}
 }

--- a/src/main/java/dragondance/scripting/functions/impl/BuiltinFunctionImport.java
+++ b/src/main/java/dragondance/scripting/functions/impl/BuiltinFunctionImport.java
@@ -42,6 +42,7 @@ public class BuiltinFunctionImport extends BuiltinFunctionBase {
 	
 	private CoverageData loadCoverage(String fileOrName) throws FileNotFoundException {
 		String prepFile;
+		String varName = super.getNameAssigneeVar();
 		CoverageData coverage=null;
 		Session session = SessionManager.getActiveSession();
 		
@@ -56,7 +57,7 @@ public class BuiltinFunctionImport extends BuiltinFunctionBase {
 			if (coverage != null)
 				return coverage;
 			
-			return guiSvc.loadCoverage(prepFile);
+			return guiSvc.loadCoverage(prepFile, varName);
 		}
 		
 		return session.getCoverageByName(fileOrName);


### PR DESCRIPTION
I couldn't load DynamoRIO coverages on Linux. Searching for the root of the problem I found the issue was due to the fact that on Linux there are more than one modules for the main executable.

The problem:
Once an entry was loaded it reads the module id and compares it with the mainModule's containing id.

The solution:
Once an entry is loaded I use its module id to retrieve the module's ModuleInfo to get the containing id, needed to compare it with the mainModule's containing id.